### PR TITLE
OT-RemoveClosedSessions | Added a way to bypass an error when sending data from front end 

### DIFF
--- a/src/main/java/offtop/Config/WebsocketHandler.java
+++ b/src/main/java/offtop/Config/WebsocketHandler.java
@@ -51,12 +51,12 @@ public class WebsocketHandler<T> extends TextWebSocketHandler {
             }
             webSocketSession = userSessions.get(userId);
 
-            TextMessage textMessage = new TextMessage("Received data!");
+            TextMessage textMessage = new TextMessage("Received Incoming Audio data!");
             try {
                 webSocketSession.sendMessage(textMessage);
             } catch (Exception ex) {
                 synchronized (sessions) {
-                    sessions.remove(webSocketSession);
+                    System.out.println(ex);
                 }
             }
         }


### PR DESCRIPTION
**What I Did:** 

- I added a try/catch block to `webSocketSession.sendMessage(textMessage);` to catch the error that prevents a server lockup in the case where the connection to the WebsSocket was disrupted improperly. 

- It looks like my auto-formatting messed with the formatting but the only real changes are on lines 53 - 61.

**How to Test:**

1. Prerequisites: You need to test this branch alongside [Off Top Flutter: OT-ConfigureRecordingForAndroid](https://github.com/Off-Top-App/off-top-flutter/pull/40) pull-request! This problem was mainly for Android devices but test on iOS as well to make sure functionality wasn't broken.

2. You will need Zookeeper/Kafka, updated Spring-boot, and Python consumer and producer running.

3. Log into the front end app and record an audio session. Watch for the data getting passed from the front end after stopping the recording from both the producer and consumer in python. Make sure that the meter will still move in the front-end using the mock data during recording.

4. Switch between the pages on the front end (ie: switch to the Settings Tab and then back to Recording Tab) and watch for the closing and opening of the connection. After the connection is opened, test step 3 again. Make sure you are able to send and receive data again and the server doesn't lockup or break. 

5. Perform a hot restart in the front end. Then test step 3 again. Make sure you are able to send and receive data again and the server doesn't lockup or break. 

6. If data is successfully produced and consumed, then the server works properly. #